### PR TITLE
Tags organization

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,15 @@
+/*
+  Contains data migrations scripts (best to just copy and paste into a page component, reload localhost once, and then remove it)
+*/
+
+// async created () {
+//   const query = db.collection(`classes/${this.$route.params.class_id}/posts`).where("tags", "array-contains", "Discussion Section (April 4))");
+//   const posts = await this.$_getCollection(query);
+//   for (const post of posts) {
+//     console.log("post =", post);
+//     await db.collection(`classes/${this.$route.params.class_id}/posts`).doc(post.id).update({
+//       tags: ["Discussion Section (April 4)"]
+//     });
+//     console.log("done processing");
+//   }
+// }

--- a/src/components/BasePopupButton.vue
+++ b/src/components/BasePopupButton.vue
@@ -19,9 +19,7 @@
             <slot name="message-to-user">
 
             </slot>
-            <slot name="popup-content" 
-              :closePopup="resetState"
-            >
+            <slot name="popup-content" :closePopup="resetState">
               <template v-for="inputField in inputFields">
                 <v-col cols="12" :key="inputField">
                   <v-text-field

--- a/src/components/BasePopupButton.vue
+++ b/src/components/BasePopupButton.vue
@@ -19,27 +19,33 @@
             <slot name="message-to-user">
 
             </slot>
-            <template v-for="inputField in inputFields">
-              <v-col cols="12" :key="inputField">
-                <v-text-field
-                  v-model="inputValues[inputField]"
-                  :label="inputField"
-                  :type="inputField"
-                  required
-                />
-              </v-col>
-            </template>
+            <slot name="popup-content" 
+              :closePopup="resetState"
+            >
+              <template v-for="inputField in inputFields">
+                <v-col cols="12" :key="inputField">
+                  <v-text-field
+                    v-model="inputValues[inputField]"
+                    :label="inputField"
+                    :type="inputField"
+                    required
+                  />
+                </v-col>
+              </template>
+            </slot>
           </v-row>
         </v-container>
       </v-card-text>
       <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn @click="resetState()" color="secondary" text>
-          Cancel
-        </v-btn>
-        <v-btn @click="doAction()" color="secondary" text>
-          {{ actionName }}
-        </v-btn>
+        <v-spacer/>
+          <v-btn @click="resetState()" color="secondary" text>
+            Cancel
+          </v-btn>
+          <slot name="popup-action-buttons">
+            <v-btn v-if="actionName" @click="doAction()" color="secondary" text>
+              {{ actionName }}
+            </v-btn>
+          </slot>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/components/FileExplorer.vue
+++ b/src/components/FileExplorer.vue
@@ -1,0 +1,205 @@
+<template>
+  <v-card class="mx-auto" max-width="500">
+    <v-sheet class="pa-4 secondary lighten-3">
+      <v-text-field
+        v-model="search"
+        label="Search existing posts..."
+        dark
+        flat
+        solo-inverted
+        hide-details
+        clearable
+        clear-icon="mdi-close-circle-outline"
+      ></v-text-field>
+    </v-sheet>
+    <v-card-text>
+      <v-treeview
+        :items="organizedPosts"
+        :search="search"
+        :load-children="(folder) => fetchRelevantPosts(folder)"
+        :key="incrementKeyToDestroy"
+      >
+        <template v-slot:prepend="{ item, open }">
+          <v-icon v-if="item.isFolder">
+            {{ open ? 'mdi-folder-open' : 'mdi-folder' }}
+          </v-icon> 
+          <v-menu v-else bottom>
+            <template v-slot:activator="{ on }">
+              <v-btn icon v-on="on">
+                <v-icon>mdi-dots-vertical</v-icon>
+              </v-btn>
+            </template>
+
+            <v-list>
+              <v-list-item>
+                <BasePopupButton>
+                  <template v-slot:activator-button="{ on }">
+                    <v-btn v-on="on" color="secondary" text>
+                      Move
+                    </v-btn>
+                  </template>
+                  <template v-slot:popup-content="{ closePopup }">
+                    <h1>Select a folder</h1>
+                    <template v-if="mitClass">
+                      <div class="text-center mt-5">
+                        <v-chip v-for="tagName in mitClass.tags" 
+                          @click="movePostToFolder(item, tagName, closePopup)"
+                          :key="tagName" 
+                          large
+                          color="accent" 
+                          class="mx-2">
+                          {{ tagName }}
+                        </v-chip>
+                      </div>
+                    </template>
+                  </template>
+                  <!-- <template v-slot:popup-action-buttons>
+                    <v-btn @click="" color="secondary" text>Confirm Move</v-btn>
+                  </template> -->
+                </BasePopupButton>
+              </v-list-item>
+              <!-- <v-list-item>
+                <BasePopupButton>
+                  <template v-slot:activator-button="{ on }">
+                    <v-btn v-on="on" color="secondary" text>Delete</v-btn>
+                  </template>
+                </BasePopupButton>
+              </v-list-item> -->
+            </v-list>
+          </v-menu>
+        </template>
+        <template v-slot:label="{ item }">
+          <v-list-item two-line v-if="!item.isFolder" :to="`/class/${mitClass.id}/posts/${item.id}`">
+            <v-list-item-content>
+              <v-list-item-subtitle v-text="item.name"></v-list-item-subtitle>
+              <v-list-item-subtitle v-text="displayDate(item.date)"></v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item v-else>
+            {{ item.name }}
+          </v-list-item>
+        </template>
+      </v-treeview>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+// TODO: Fix search; Allow user to edit; Fix the strange nesting
+import DatabaseHelpersMixin from "@/mixins/DatabaseHelpersMixin.js"; 
+import BasePopupButton from "@/components/BasePopupButton.vue";
+import { displayDate } from "@/helpers.js";
+import db from "@/database.js";
+import firebase from "firebase/app";
+import "firebase/firestore";
+
+export default {
+  mixins: [
+    DatabaseHelpersMixin
+  ],
+  components: {
+    BasePopupButton
+  },
+  computed: {
+    mitClass () {
+      return this.$store.state.mitClass;
+    }
+  },
+  data: () => ({
+    organizedPosts: [],
+    search: null,
+    incrementKeyToDestroy: 0
+  }),
+  watch: {
+    mitClass: {
+      immediate: true,
+      handler () {
+        if (!this.mitClass) return; 
+        let i = 0;
+        for (const tag of this.mitClass.tags) {
+          this.organizedPosts.push({
+            id: i,
+            name: tag,
+            isFolder: true,
+            children: [],
+            date: "999999999999999999999999999999999999999" // so it'll always appear at the top
+          });
+          i += 1;
+        }
+        this.fetchPostsWithNoTags(); 
+      }
+    }
+  },
+  methods: {
+    async fetchPostsWithNoTags () {
+      const query = db.collection(`classes/${this.$route.params.class_id}/posts`).where("tags", "==", []);
+      this.bindUntaggedPostsToDatabase(query);
+    },
+    async fetchRelevantPosts (item) {
+      const { class_id }  = this.$route.params; 
+      const postsQuery = db.collection(`classes/${class_id}/posts`).where("tags", "array-contains", item.name);
+      await this.bindArrayToDatabase(item.children, postsQuery);
+    },
+    async movePostToFolder (post, folder, closePopup) {
+      const postRef = db.doc(`classes/${this.$route.params.class_id}/posts/${post.id}`);
+      await postRef.update({
+        tags: [folder] // a file can only exist in one folder at the time (for now)
+      });
+      this.$root.$emit("show-snackbar", "Successfully moved post to the specified folder");
+      closePopup();
+    },
+    bindUntaggedPostsToDatabase (queryRef) {
+      queryRef.onSnapshot((snapshot) => {
+        snapshot.docChanges().forEach((change) => {
+          if (change.type === "added") {
+            const post = {
+              id: change.doc.id,
+              name: change.doc.data().title,
+              date: change.doc.data().date
+            };
+            this.organizedPosts.push(post);
+            this.organizedPosts.sort((a, b) => (a.date < b.date) ? 1 : ((a.date > b.date) ? -1 : 0));
+          } else if (change.type === "removed") {
+            for (let i = 0; i < this.organizedPosts.length; i++) {
+              const post = this.organizedPosts[i];
+              if (post.id === change.doc.id) {
+                this.organizedPosts.splice(i, 1); // removes `1` element from position `i`
+                this.incrementKeyToDestroy += 1; // re-render the tree
+              }
+            }
+          }
+        });
+      });
+    },
+    bindArrayToDatabase (array, queryRef) {
+      return new Promise((resolve) => {
+        queryRef.onSnapshot((snapshot) => {
+          const temporaryArray = []; // so we hydrate `array` all at once after we collected each "added" document
+          snapshot.docChanges().forEach((change) => {
+            if (change.type === "added") {
+              temporaryArray.push({
+                id: change.doc.id,
+                name: change.doc.data().title,
+                date: change.doc.data().date 
+              });
+            } else if (change.type === "removed") {
+              // below hack is necessary because <treeview> only reacts to `.push()` and not removal operations
+              let arrayCopy = [...array];
+              arrayCopy = arrayCopy.filter((post) => post.id !== change.doc.id);
+              array.length = 0; // empty the array
+              array.push(...arrayCopy);
+              this.incrementKeyToDestroy += 1;
+            }
+          });
+          array.push(...temporaryArray);
+          array.sort((a, b) => (a.date < b.date) ? 1 : ((a.date > b.date) ? -1 : 0));
+          resolve();
+        });
+      })
+    },
+    displayDate (date) {
+      return displayDate(date);
+    }
+  }
+};
+</script>

--- a/src/components/TheSideDrawer.vue
+++ b/src/components/TheSideDrawer.vue
@@ -5,7 +5,7 @@
       @input="(newVal) => $emit('input', newVal)" 
       app 
       clipped 
-      width="325"
+      width="400"
     >
       <!-- <v-btn text :to="(`/class/${classId}`)" block large color="accent" class="my-1">
         <v-icon class="pr-2">mdi-home</v-icon> 

--- a/src/components/TheSideDrawer.vue
+++ b/src/components/TheSideDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card style="zIndex:10">
+  <v-card>
     <v-navigation-drawer 
       :value="value" 
       @input="(newVal) => $emit('input', newVal)" 
@@ -11,8 +11,7 @@
         <v-icon class="pr-2">mdi-home</v-icon> 
         Overview
       </v-btn> -->
-      <v-tabs
-        v-model="activeTab"
+      <v-tabs v-model="activeTab"
         grow
         active-class="accent--text"
         class="side-tabs"
@@ -23,51 +22,18 @@
       </v-tabs>
       <v-tabs-items v-model="activeTab">
         <v-tab-item key="Forum">
-          <v-list class="pt-0">
+          <v-list class="py-0">
             <v-list-item :to="(`/class/${classId}/posts/new`)" color="accent">
               <v-list-item-icon>
                 <v-icon>mdi-plus</v-icon>
               </v-list-item-icon>
               <v-list-item-content>
-                <v-list-item-title>Start a new post</v-list-item-title>
+                <v-list-item-title>New Post</v-list-item-title>
               </v-list-item-content>
             </v-list-item> 
-
-            <v-list-item>
-              <!-- TODO: re-use BaseSearchBar -->
-              <v-autocomplete
-                placeholder="Search existing posts..."
-                :items="posts"
-                item-text="title"
-                @change="(selectedPost) => displayFullPost(selectedPost)"
-                outlined
-                clearable
-                hide-details
-                prepend-inner-icon="mdi-magnify"
-                return-object
-                color="accent"
-                ref="SearchBar"
-                style="zIndex:11"
-              />
-            </v-list-item>
-            <template v-for="(post, i) in posts">
-              <v-list-item 
-                :key="post.id + i"
-                :to="`/class/${classId}/posts/${post.id}`"
-                three-line 
-                color="accent"
-              >
-                <v-list-item-content>
-                  <v-list-item-subtitle class="text--primary" v-text="post.title || '(No title)'"/>
-                  <v-list-item-subtitle v-text="displayDate(post.date)"/>
-                </v-list-item-content>
-              </v-list-item>
-              <v-divider
-                v-if="i + 1 < posts.length"
-                :key="i"
-              ></v-divider>
-            </template>
           </v-list>
+          <!-- File Explorer -->
+          <FileExplorer/>
         </v-tab-item>
         <v-tab-item key="Blackboard">
           <v-btn v-if="blackboards"
@@ -125,6 +91,7 @@
 </template>
 
 <script>
+import FileExplorer from "@/components/FileExplorer.vue";
 import DatabaseHelpersMixin from "@/mixins/DatabaseHelpersMixin.js";
 import { tutorial } from "@/CONSTANTS.js";
 import { displayDate } from "@/helpers.js";
@@ -137,6 +104,9 @@ export default {
   mixins: [
     DatabaseHelpersMixin
   ],
+  components: {
+    FileExplorer,
+  },
   data () {
     return {
       posts: [],

--- a/src/components/TheSideDrawer.vue
+++ b/src/components/TheSideDrawer.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Commented out z-index so dropdown menus will show, but now tabs are submerged-->
   <v-card>
     <v-navigation-drawer 
       :value="value" 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,9 +9,12 @@ export const displayDate = function (dateString) {
 } 
 
 export const getRandomId = function () {
-  return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  );
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let autoId = '';
+  for (let i = 0; i < 20; i++) {
+    autoId += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return autoId;
 }
 
 export function isIosSafari () {

--- a/src/mixins/DatabaseHelpersMixin.js
+++ b/src/mixins/DatabaseHelpersMixin.js
@@ -1,7 +1,6 @@
 import firebase from "firebase/app";
 import "firebase/storage";
 
-// Every CRUD operation has explicit error handling without making the codebase verbose
 export default {
   methods: {
     async $_getDoc (ref) {
@@ -11,7 +10,13 @@ export default {
           if (!doc.exists) {
             this.$root.$emit("show-snackbar", `Error: data doesn't exist for path = ${ref.path}`);
             reject();
-          } else { resolve({ "id": doc.id, "ref": doc.ref.path, ...doc.data() }); } 
+          } else { 
+            resolve({ 
+              id: doc.id, 
+              ref: doc.ref.path, 
+              ...doc.data() 
+            }); 
+          } 
         } catch (error) {
           this.$root.$emit("show-snackbar", error.message);
           reject("Error: cannot fetch doc");
@@ -24,11 +29,16 @@ export default {
           const results = [];
           const collectionSnapshot = await ref.get();
           collectionSnapshot.forEach(doc => {
-            results.push({ "id": doc.id, "ref": doc.ref.path, ...doc.data() });
+            results.push({ 
+              id: doc.id, 
+              ref: doc.ref.path, 
+              ...doc.data() 
+            });
           });
           resolve(results);
         } catch (error) {
           this.$root.$emit("show-snackbar", error.message);
+          console.log("error =", error);
           reject();
         }
       });
@@ -37,7 +47,11 @@ export default {
       return new Promise(async (resolve) => {
         try {
           const unsubscribeListener = ref.onSnapshot((doc) => { // onSnapshot does NOT return a promise
-            obj[val] = { "id": doc.id, "ref": doc.ref.path, ...doc.data(), }
+            obj[val] = { 
+              id: doc.id, 
+              ref: doc.ref.path, 
+              ...doc.data(), 
+            };
             resolve(unsubscribeListener);
           });
         } catch (error) {

--- a/src/pages/ClassPageNewPost.vue
+++ b/src/pages/ClassPageNewPost.vue
@@ -9,14 +9,12 @@
 </template>
 
 <script>
-import TheAppBar from "@/components/TheAppBar.vue";
 import CreateExplanation from "@/components/CreateExplanation.vue";
 import db from "@/database.js";
 import { getRandomId } from "@/helpers.js";
 
 export default {
   components: { 
-    TheAppBar, 
     CreateExplanation,
   },
   data () {
@@ -42,10 +40,9 @@ export default {
     if (Blackboard.getStrokesArray().length > 0 || TextEditor.extractAllText().length > 0) {
       const wantToLeave = window.confirm("Do you really want to leave? You might have unsaved changes.");
       if (wantToLeave) next();
-      else next(false);
-    } else {
-      next();
-    }
+      else next(false); 
+    } 
+    else next(); 
   },
   methods: {
     resetExplanationComponent () {

--- a/src/pages/ClassPageSeePost.vue
+++ b/src/pages/ClassPageSeePost.vue
@@ -6,7 +6,7 @@
     />
     <CreateExplanation 
       :postDbRef="postRef"
-      :newExplanationDbRef="explanationsRef.doc()" 
+      :newExplanationDbRef="explanationsRef" 
       ref="CreateExplanation"
     />
   </div>
@@ -72,9 +72,8 @@ export default {
         const wantToLeave = window.confirm("Do you really want to leave? You might have unsaved changes.");
         if (!wantToLeave) { next(false); }
         else { next(); }
-      } else {
-        next();
-      }
+      } 
+      else { next(); }
     }
   }
 }

--- a/src/pages/ClassPageSeePost.vue
+++ b/src/pages/ClassPageSeePost.vue
@@ -70,10 +70,10 @@ export default {
 
       if (Blackboard.getStrokesArray().length > 0 || TextEditor.extractAllText().length > 0) {
         const wantToLeave = window.confirm("Do you really want to leave? You might have unsaved changes.");
-        if (!wantToLeave) { next(false); }
-        else { next(); }
+        if (!wantToLeave) next(false);
+        else next(); 
       } 
-      else { next(); }
+      else next(); 
     }
   }
 }

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -131,7 +131,6 @@ import TheSearchBar from "@/components/TheSearchBar.vue";
 import RenderlessAsync from "@/components/RenderlessAsync.vue";
 import BasePopupButton from "@/components/BasePopupButton.vue";
 import DatabaseHelpersMixin from "@/mixins/DatabaseHelpersMixin.js";
-import Blackboard from "@/components/Blackboard.vue";
 import SeeExplanation from "@/components/SeeExplanation.vue";
 import CreateExplanation from "@/components/CreateExplanation.vue";
 import { demoVideo, NotifFrequency, DefaultEmailSettings } from "@/CONSTANTS.js";
@@ -141,7 +140,6 @@ export default {
   components: {
     RenderlessAsync, 
     BasePopupButton,
-    Blackboard,
     SeeExplanation,
     CreateExplanation,
     TheAppBar,
@@ -249,6 +247,7 @@ export default {
       const classDoc = await db.collection("classes").add({
         name,
         description: description || "No description yet",
+        tags: []
       });
       await this.userRef.update({
         enrolledClasses: firebase.firestore.FieldValue.arrayUnion({


### PR DESCRIPTION
Folders are less flexible than hierarchical tags,  but there are strengths to it as well (akin to how immutability is often an advantage rather than a disadvantage). 

For example, folder contents are guaranteed to be mutually exclusive, and together will form a complete partition of the entire class page's content. That makes it easy to code the real-time listeners for Firestore - each folder is listening to a distinct region of the posts collection. 

Furthermore, because each folder, when expanded, will asynchronously fetch data from Firestore, folders ensure that our data fetch is light. Currently, the initial fetch only contains posts that don't belong in a folder. lastly 

Lastly, from UI's perspective, it's intuitive that when a user moves a post into another folder that it disappears from the original folder.

In any case, the implementation can be extended in the future. Currently, a post belongs to folder "Office Hours" if the `tags` property is `["Physics"]. Whenever the user move the post, the `tags` array's first element will be overwritten (thereby enforcing that all posts belong only to one folder). Removing that restriction will allow a post to belong to multiple tags at once. 

