### PR TITLE
Fix blackboard bugs

### DIFF
--- a/src/components/Blackboard.vue
+++ b/src/components/Blackboard.vue
@@ -42,6 +42,7 @@
             <ButtonNew v-if="!isRecording" @click="startRecording()" icon="mdi-adjust" filled>
               Record Audio
             </ButtonNew>
+            
             <ButtonNew v-else @click="stopRecording()" icon="mdi-stop" filled>
               Finish Recording
             </ButtonNew>
@@ -64,7 +65,7 @@
     - Saving: The user can save the state of the blackboard as a replayable animation. 
     - Recording: By pressing "record", the user can record a voiced video explanation. 
 
- * Maintains the invariant that the UI <canvas/> contains exactly the strokes from `strokesArray`. 
+ * Maintains the invariant that the UI <canvas/> displays exactly the strokes from `strokesArray`. 
  * Manages its own state i.e. currentTime, strokesArray, audioBlob and imageBlob.
 */
 import BlackboardToolBar from "@/components/BlackboardToolBar.vue";

--- a/src/components/Blackboard.vue
+++ b/src/components/Blackboard.vue
@@ -4,7 +4,7 @@
       :strokesArray="strokesArray" @stroke-drawn="stroke => $emit('stroke-drawn', stroke)"
       :currentTime="currentTime"
       :isRealtime="isRealtime"
-      @mounted="getThumbnailBlob => $emit('mounted', getThumbnailBlob)"
+      @mounted="blackboardMethods => $emit('mounted', blackboardMethods)"
       @update:thumbnailBlob="blob => $emit('update:thumbnailBlob', blob)"
       @update:bgImageBlob="blob => $emit('update:bgImageBlob', blob)"
       @board-reset="$emit('board-reset')"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,6 +17,9 @@ export const getRandomId = function () {
   return autoId;
 }
 
+/**
+ * TODO: currently fails to detect iPad Safari
+ */
 export function isIosSafari () {
   return navigator.userAgent.match(/iP(od|hone|ad)/) &&
     navigator.userAgent.match(/AppleWebKit/) &&


### PR DESCRIPTION
While there is no problem with our correctness argument, our implementation doesn't actually listen to the "board-reset" event (now fixed). Furthermore, when doing a forced re-render with `incrementKeyToDestroy`, it's necessary to reset strokesArray (now fixed).

![image](https://user-images.githubusercontent.com/26662928/85216411-e70c8a80-b3b6-11ea-8d92-341a7287f3a5.png)