### PR TITLE
Display posts compactly

### DIFF
--- a/src/components/FileExplorerByDate.vue
+++ b/src/components/FileExplorerByDate.vue
@@ -61,12 +61,10 @@
               <drop class="drop" @drop="handleDrop(item, ...arguments)">
                 <drag class="drag" :key="item.id" :transfer-data="{ data: item }">
                   <v-list-item v-if="!item.isFolder" :to="`/class/${mitClass.id}/posts/${item.id}`" dense>
-                    <v-list-item-content>
-                      <v-list-item-subtitle v-text="item.name"></v-list-item-subtitle>
-                    </v-list-item-content>
+                    <v-list-item-subtitle v-text="item.name"/>
                   </v-list-item>
-                  <v-list-item v-else>
-                    {{ item.name }}
+                  <v-list-item v-else dense>
+                    <v-list-item-subtitle v-text="item.name"/>
                   </v-list-item>
                 </drag>
               </drop>
@@ -149,6 +147,7 @@
                   </v-list-item>
                 </v-list>
               </v-menu>
+
             </template>
           </v-treeview>
     </div>

--- a/src/components/FileExplorerByDate.vue
+++ b/src/components/FileExplorerByDate.vue
@@ -52,7 +52,60 @@
               <v-icon v-if="item.isFolder">
                 {{ open ? 'mdi-folder-open' : 'mdi-folder' }}
               </v-icon> 
-              <!-- cannot move/edit posts if not logged in -->
+              <v-icon v-else>
+                mdi-file-document
+              </v-icon>
+            </template>
+
+            <template v-slot:label="{ item }">
+              <drop class="drop" @drop="handleDrop(item, ...arguments)">
+                <drag class="drag" :key="item.id" :transfer-data="{ data: item }">
+                  <v-list-item v-if="!item.isFolder" :to="`/class/${mitClass.id}/posts/${item.id}`" dense>
+                    <v-list-item-content>
+                      <v-list-item-subtitle v-text="item.name"></v-list-item-subtitle>
+                    </v-list-item-content>
+                  </v-list-item>
+                  <v-list-item v-else>
+                    {{ item.name }}
+                  </v-list-item>
+                </drag>
+              </drop>
+            </template>
+
+            <template v-slot:append="{ item }">
+              <v-menu v-if="user && item.isFolder" bottom right>
+                <template v-slot:activator="{ on }">
+                  <v-btn icon v-on="on">
+                    <v-icon>mdi-dots-vertical</v-icon>
+                  </v-btn>
+                </template>
+
+                <v-list>
+                  <v-list-item>
+                    <BasePopupButton actionName="Rename Folder" 
+                      :inputFields="['New Name']"
+                      @action-do="payload => renameTag(payload, item)"
+                    >
+                      <template v-slot:activator-button="{ on }">
+                        <v-btn v-on="on" color="accent" text>Rename</v-btn>
+                      </template>
+                    </BasePopupButton>
+                  </v-list-item>
+                  <!-- Ability to create a sub-folder -->
+                  <v-list-item>
+                    <BasePopupButton actionName="Create Sub-folder"
+                      :inputFields="['Folder name']"
+                      @action-do="({ 'Folder name': name }) => createNewFolder(name, item.id)"
+                    >
+                      <template v-slot:activator-button="{ on }">
+                         <v-btn v-on="on" color="accent">Create Sub-folder</v-btn>
+                      </template>
+                    </BasePopupButton>
+                  </v-list-item>
+                </v-list>
+              </v-menu>
+              
+              <!-- Different dropdown options for pages (refactor later) -->
               <v-menu v-else-if="user" bottom right>
                 <template v-slot:activator="{ on }">
                   <v-btn icon v-on="on">
@@ -91,54 +144,6 @@
                     >
                       <template v-slot:activator-button="{ on }">
                         <v-btn v-on="on" color="secondary" text>RENAME</v-btn>
-                      </template>
-                    </BasePopupButton>
-                  </v-list-item>
-                </v-list>
-              </v-menu>
-            </template>
-            <template v-slot:label="{ item }">
-              <drop class="drop" @drop="handleDrop(item, ...arguments)">
-                <drag class="drag" :key="item.id" :transfer-data="{ data: item }">
-                  <v-list-item two-line v-if="!item.isFolder" :to="`/class/${mitClass.id}/posts/${item.id}`">
-                    <v-list-item-content>
-                      <v-list-item-subtitle v-text="item.name"></v-list-item-subtitle>
-                      <v-list-item-subtitle v-text="displayDate(item.date)"></v-list-item-subtitle>
-                    </v-list-item-content>
-                  </v-list-item>
-                  <v-list-item v-else>
-                    {{ item.name }}
-                  </v-list-item>
-                </drag>
-              </drop>
-            </template>
-            <template v-slot:append="{ item }">
-              <v-menu v-if="user && item.isFolder" bottom right>
-                <template v-slot:activator="{ on }">
-                  <v-btn icon v-on="on">
-                    <v-icon>mdi-dots-vertical</v-icon>
-                  </v-btn>
-                </template>
-
-                <v-list>
-                  <v-list-item>
-                    <BasePopupButton actionName="Rename Folder" 
-                      :inputFields="['New Name']"
-                      @action-do="(payload) => renameTag(payload, item)"
-                    >
-                      <template v-slot:activator-button="{ on }">
-                        <v-btn v-on="on" color="accent" text>Rename</v-btn>
-                      </template>
-                    </BasePopupButton>
-                  </v-list-item>
-                  <!-- Ability to create a sub-folder -->
-                  <v-list-item>
-                    <BasePopupButton actionName="Create Sub-folder"
-                      :inputFields="['Folder name']"
-                      @action-do="({ 'Folder name': name }) => createNewFolder(name, item.id)"
-                    >
-                      <template v-slot:activator-button="{ on }">
-                         <v-btn v-on="on" color="accent">Create Sub-folder</v-btn>
                       </template>
                     </BasePopupButton>
                   </v-list-item>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -44,7 +44,7 @@
               </h1>
             </div>
             <h3 class="headline font-weight-light">
-              A vibrant place where students, TAs and professors explain things to each other. 
+              A vibrant place where students, TAs and professors explain things to each other. [NOTE: WE'RE CURRENTLY WORKING ON BREAKING CHANGES!]
             </h3>
             <!-- Log in / Sign up -->
             <v-row class="my-5" justify="center">


### PR DESCRIPTION
This PR includes the following changes:
- Display posts more compactly
- Display a page icon next to posts; 
- Always place triple-dot dropdowns on the right for consistency

### Before
![image](https://user-images.githubusercontent.com/26662928/85953437-ce960480-b9a2-11ea-84b5-d56cc5e3e5bc.png)


### After 
![image](https://user-images.githubusercontent.com/26662928/85953441-d48be580-b9a2-11ea-9af6-d9987b07811d.png)